### PR TITLE
interface: eliminate functions that operate on interfaces

### DIFF
--- a/fixtures/fuzzable.go
+++ b/fixtures/fuzzable.go
@@ -33,6 +33,14 @@ func NoDynamicCall(a string) string {
 	return b(a)
 }
 
+type Foo interface {
+	Bar()
+}
+
+func NoInterface(a Foo) {
+	a.Bar()
+}
+
 func YesAnonymousDynamicCall() string {
 	a := "hi"
 	b := func() string { return a }


### PR DESCRIPTION
unless you know the concrete implementation of the interface, we cannot
determine whether it will depend on global state.
