### PR TITLE
add ability to whitelist function calls and global variable reads

### DIFF
--- a/analyze_test.go
+++ b/analyze_test.go
@@ -28,6 +28,9 @@ func TestAnalyze(t *testing.T) {
 		"YesAppend":                 false,
 		"yes":                       false,
 		"YesPanic":                  false,
+		"YesRead":                   false,
+		"YesLog":                    false,
+		"YesErr":                    false,
 	}
 
 	conf := loader.Config{Build: &build.Default}

--- a/fixtures/fuzzable.go
+++ b/fixtures/fuzzable.go
@@ -1,8 +1,12 @@
 package fixtures
 
 import (
+	bin "encoding/binary"
+	"errors"
 	"fmt"
+	"log"
 	"net/http"
+	"os"
 	"strings"
 )
 
@@ -13,9 +17,10 @@ import (
 
 var startString = "start"
 var b func(a string) string = func(a string) string { return a }
+var e = errors.New("custom err")
 
 func NoPrint(a string) {
-	fmt.Println(a)
+	fmt.Fprintln(os.Stdout, a)
 }
 
 func NoNet(a string) error {
@@ -117,6 +122,24 @@ func NoWriter() {
 	}
 	x.NoWrite()
 
+}
+
+func YesRead() uint16 {
+	var out uint16
+	bin.BigEndian.PutUint16([]byte{0x0, 0x01}, out)
+	return out
+}
+
+func YesLog() {
+	log.Println("Foobar")
+}
+
+func YesErr() error {
+	return e
+}
+
+func NoWriteErr() {
+	e = errors.New("foo")
 }
 
 // TODO: do i care if it mutates the input?


### PR DESCRIPTION
Resolves https://github.com/tam7t/cautious-pancake/issues/12

Does a few things:
- Whitelists all read of global variables that are of type `error`
- Configurable whitelist for function calls (including `log.Println` and `fmt.Println`)
- Configurable whitelist for global variable reads (currently only `binary.BigEndian` and `binary.LittleEndian`)