### PR TITLE
generator params

### DIFF
--- a/cmd/pancakeid/main.go
+++ b/cmd/pancakeid/main.go
@@ -54,7 +54,8 @@ import (
 
 func main() { {{ $length := len .Params }}{{if gt $length 0}}
 	f := fuzz.New(){{end}}
-	{{range $i, $v := .Params}}var p{{$i}} {{$v.Type.String}}{{end}}
+{{range $i, $v := .Params}}	var p{{$i}} {{$v.Type.String}}
+{{end}}
 	defer func() {
 		if r := recover(); r != nil {
 			fmt.Println("found panic", r){{range $i, $v := .Params}}
@@ -63,7 +64,7 @@ func main() { {{ $length := len .Params }}{{if gt $length 0}}
 	}()
 	for { {{range $i, $v := .Params}}
 		f.Fuzz(&p{{$i}}){{end}}
-		{{.Package.Pkg.Name}}.{{.Name}}({{range $i, $v := .Params}}p{{$i}}{{if $i}}, {{end}}{{end}})
+		{{.Package.Pkg.Name}}.{{.Name}}({{range $i, $v := .Params}}{{if $i}}, {{end}}p{{$i}}{{end}})
 	}
 }`
 

--- a/cmd/pancakeid/main.go
+++ b/cmd/pancakeid/main.go
@@ -7,6 +7,7 @@ import (
 	"go/build"
 	"html/template"
 	"log"
+	"path"
 
 	cautiouspancake "github.com/tam7t/cautious-pancake"
 
@@ -54,7 +55,7 @@ import (
 
 func main() { {{ $length := len .Params }}{{if gt $length 0}}
 	f := fuzz.New(){{end}}
-{{range $i, $v := .Params}}	var p{{$i}} {{$v.Type.String}}
+{{range $i, $v := .Params}}	var p{{$i}} {{$v.Type.String | strippkg}}
 {{end}}
 	defer func() {
 		if r := recover(); r != nil {
@@ -70,7 +71,9 @@ func main() { {{ $length := len .Params }}{{if gt $length 0}}
 
 func PrintFuzz(f *ssa.Function) string {
 	var out bytes.Buffer
-	tmpl := template.Must(template.New("").Parse(fuzzTemp))
+	tmpl := template.Must(template.New("").Funcs(template.FuncMap{"strippkg": func(a interface{}) string {
+		return path.Base(a.(string))
+	}}).Parse(fuzzTemp))
 	tmpl.Execute(&out, f)
 	return out.String()
 }


### PR DESCRIPTION
fixes newlines between multiple variables in generated code 
```
var p0 stringvar p1 string

to

var p0 string
var p1 string
```

& parameter type (big hack, removes pointer info and only works on the tested packages type):

```
var p0 github.com/tam7t/cautious-pancake/fixtures.MyStuffvar

to

var p0 fixtures.MyStuffvar
```
