### PR TITLE
bugfix: single param non pointer did not initialize fuzzer

### DIFF
--- a/cmd/pancakegen/main.go
+++ b/cmd/pancakegen/main.go
@@ -52,8 +52,10 @@ import (
 	"{{.Package.Pkg.Path}}"
 )
 
-func main() { {{if gt (len .Params) 0}}{{if or ( (gt (len .Params) 1) (not fuzznil .) )}}
-	f := fuzz.New(){{end}}{{if fuzznil .}}
+func main() { {{if gt (len .Params) 0}}{{if not (fuzznil .) }}
+	f := fuzz.New(){{end}}{{if fuzznil .}}{{if gt (len .Params) 1}}
+	f := fuzz.New()
+	{{end}}
 	f1 := fuzz.New().NilChance(0){{end}}{{end}}
 
 {{range $i, $v := .Params}}	var p{{$i}} {{$v.Type | strippkg}}


### PR DESCRIPTION
https://github.com/tam7t/cautious-pancake/pull/28 introduced a regression where

`go run cmd/pancakegen/main.go -pkg=github.com/tam7t/cautious-pancake/fixtures -func=YesMaybePanic`

did not initialize `f`. the `(not fuzznil .)` portion of the conditional was not evaluated correctly for 'some reason'