### PR TITLE
pancakeinfo: better flags and tabwriter output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,16 @@ Given a package, `pancakeinfo` will tell you which functions are pure:
 ```
 $ go get -u github.com/tam7t/cautious-pancake/cmd/pancakeinfo
 $ pancakeinfo -pkg=github.com/mdlayher/arp
-NewPacket Pure
-(Client).HardwareAddr Pure
-(*Packet).MarshalBinary Pure
-(*Packet).UnmarshalBinary Pure
+(Operation).String
+NewPacket
+(Client).HardwareAddr
+(*Packet).UnmarshalBinary
+(*Packet).MarshalBinary
 ```
 
-The `-filter=impure` flag will return all functions deemed impure, including
-the reason for the determination and the `-all` flag will display information
-on private functions as well.
+The `-pure=false` flag will return all functions deemed impure, including
+the reason for the determination and the `-private` flag will display
+information on private functions as well.
 
 ### `pancakegen`
 Given a package and a function, `pancakegen` will generate code to fuzz that

--- a/analyze.go
+++ b/analyze.go
@@ -71,6 +71,21 @@ func (n *Node) Pure() bool {
 	return (n.RuleBasic == nil && n.RuleInterface == nil && n.RuleCallee == nil)
 }
 
+// Reason returns descriptive strings for why a node is not pure.
+func (n *Node) Reason() (string, string) {
+	if n.RuleBasic != nil {
+		return "basic", fmt.Sprintf("%s", n.CallGraph.Prog.Fset.Position(*n.RuleBasic))
+	}
+	if n.RuleInterface != nil {
+		return "iface", fmt.Sprintf("%s", n.CallGraph.Prog.Fset.Position(*n.RuleInterface))
+	}
+	if n.RuleCallee != nil {
+		return "calls", fmt.Sprintf("%s", n.RuleCallee)
+	}
+	return "", ""
+
+}
+
 func (n *Node) String() string {
 	if n.RuleBasic != nil {
 		return fmt.Sprintf("Impure - basic - %s", n.CallGraph.Prog.Fset.Position(*n.RuleBasic))

--- a/cmd/pancakeinfo/main.go
+++ b/cmd/pancakeinfo/main.go
@@ -4,7 +4,10 @@ import (
 	"flag"
 	"fmt"
 	"go/build"
+	"io"
 	"log"
+	"os"
+	"text/tabwriter"
 
 	cautiouspancake "github.com/tam7t/cautious-pancake"
 
@@ -14,8 +17,12 @@ import (
 
 func main() {
 	pkgPtr := flag.String("pkg", "", "path to analyze")
-	filterPtr := flag.String("filter", "pure", "show pure | impure functions")
-	allPtr := flag.Bool("all", false, "include private functions")
+	purePtr := flag.Bool("pure", true, "display pure functions")
+	privatePtr := flag.Bool("private", false, "display private functions")
+	noArgs := flag.Bool("noargs", true, "display functions with zero arguments")
+	debugPtr := flag.Bool("debug", false, "display info from all packages")
+	tracePtr := flag.Bool("trace", false, "print call graphs for why something is impure")
+
 	flag.Parse()
 
 	// Load, parse and type-check the whole program.
@@ -32,20 +39,55 @@ func main() {
 		log.Fatal(err)
 	}
 
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', tabwriter.DiscardEmptyColumns|tabwriter.TabIndent)
+
 	for k, v := range cg.Mapping {
 		if k == nil {
 			continue
 		}
-		if _, ok := cg.Prog.Imported[k.Package().Pkg.Path()]; ok {
-			if *allPtr || isExported(k) {
-				if (*filterPtr == "pure" && v.Pure()) || (*filterPtr == "impure" && !v.Pure()) {
-					fmt.Println(k.RelString(k.Package().Pkg), v)
-				}
-			}
+
+		if _, ok := cg.Prog.Imported[k.Package().Pkg.Path()]; !ok && !*debugPtr {
+			continue
+		}
+
+		if len(k.Params) == 0 && !*noArgs {
+			continue
+		}
+
+		if !*privatePtr && !isExported(k) {
+			continue
+		}
+
+		if *purePtr && !v.Pure() {
+			continue
+		}
+
+		if !*purePtr && v.Pure() {
+			continue
+		}
+
+		why, where := v.Reason()
+		fmt.Fprintf(w, "%s\t%s\t%s\n", k.RelString(k.Package().Pkg), why, where)
+		if v.RuleCallee != nil && *tracePtr {
+			printTrace(w, cg, v.RuleCallee)
+			w.Flush()
 		}
 	}
+	w.Flush()
 }
 
 func isExported(f *ssa.Function) bool {
 	return f.Object() != nil && f.Object().Exported()
+}
+
+func printTrace(w io.Writer, cg *cautiouspancake.CallGraph, k *ssa.Function) {
+	v := cg.Mapping[k]
+	why, where := v.Reason()
+	fmt.Fprintf(w, "*\t*\t%s\t%s\t%s\n", k.RelString(k.Package().Pkg), why, where)
+
+	if v.RuleCallee == nil {
+		return
+	}
+
+	printTrace(w, cg, v.RuleCallee)
 }


### PR DESCRIPTION
Add flag for Issue #32:
```
  -noargs
        display functions with zero arguments (default true)
```
Replace `-filter` with individual flags:
```
  -debug
        display info from all packages
  -private
        display private functions
  -pure
        display pure functions (default true)
```
Helper for tracking down reasons
```
  -trace
        print call graphs for why something is impure
```